### PR TITLE
RAM issues with STAR

### DIFF
--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -19,8 +19,7 @@ rule all:
         TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT,
         'result/5_combined/combined_feature_counts.tsv',
         'result/5_combined/combined_flagstat.tsv',
-        'result/5_combined/combined_picard.tsv',
-        'log/STAR_remove.log'
+        'result/5_combined/combined_picard.tsv'
         
 ##----------------------------------------##
 ## 1. Adapter removal & quality filtering ##
@@ -106,7 +105,7 @@ if (not os.path.exists(STAR_index_SA)):
             BAM = rules.STAR_align.output,
             IDX = 'ref/release' + config["release"] + '/STARindex/'
         message: 'Removing genome from RAM'
-        log: "log/STAR_remove.log"
+        log: "log/STAR_remove.benchmark.txt"
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
@@ -132,7 +131,7 @@ else:
             BAM = rules.STAR_align2.output,
             IDX = expand('ref/release{release}/STARindex', release=config["release"])
         message: 'Removing genome from RAM'
-        log: "log/STAR_remove.log"
+        benchmark: "log/STAR_remove.benchmark.txt"
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
@@ -207,6 +206,6 @@ rule combine:
         pic_all = 'result/5_combined/combined_picard.tsv'
     threads: 1
     message: "Combining samples"
-    benchmark: 'log/fcount/combine.benchmark.txt'
+    benchmark: 'log/combine.benchmark.txt'
     run:
         shell("python scripts/combine_samples.py")

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -75,7 +75,7 @@ STAR_index_SA = 'ref/release' + config["release"] + '/STARindex/SA'
 rule STAR_index:
     input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
     output: 
-        STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
+        STAR_index = ancient(directory(expand('ref/release{release}/STARindex', release=config["release"]))),
         gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
     params:
         release = config["release"],

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -19,8 +19,7 @@ rule all:
         TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT,
         'result/5_combined/combined_feature_counts.tsv',
         'result/5_combined/combined_flagstat.tsv',
-        'result/5_combined/combined_picard.tsv',
-        'log/STAR_remove.benchmark.txt'
+        'result/5_combined/combined_picard.tsv'
         
 ##----------------------------------------##
 ## 1. Adapter removal & quality filtering ##

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -125,7 +125,7 @@ rule STAR_align:
 rule STAR_remove:
     input:
         LOAD_done = 'log/benchmark/STAR_load.benchmark.txt',
-        BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+        BAM = expand('result/2_bam/{sample}_Aligned.sortedByCoord.out.bam', sample=SAMPLES)
     output: 
         REMOVE_done = touch('log/benchmark/STAR_remove.benchmark.txt')
     params:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -104,7 +104,7 @@ rule STAR_load:
         LOAD_done = touch('log/benchmark/STAR_load.benchmark.txt')
     params:
         release = config["release"]
-    threads: config["threads"]
+    threads: config["threads"] * 0.25
     message: 'Loading genome index'
     run:
         shell("STAR --genomeDir 'ref/release{params.release}/STARindex' --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -75,7 +75,7 @@ STAR_index_SA = 'ref/release' + config["release"] + '/STARindex/SA'
 rule STAR_index:
     input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
     output: 
-        STAR_index = ancient(directory(expand('ref/release{release}/STARindex', release=config["release"]))),
+        STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
         gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
     params:
         release = config["release"],

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -79,7 +79,7 @@ if (not os.path.exists(STAR_index_SA)):
         output: 
             STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
             gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf',
-            IDX.done = touch('log/benchmark/STAR_index.benchmark.txt')
+            IDX_done = touch('log/benchmark/STAR_index.benchmark.txt')
         params:
             release = config["release"],
             genome = config["genome"]
@@ -91,9 +91,9 @@ if (not os.path.exists(STAR_index_SA)):
 rule STAR_load:
     input:
         IDX = rules.STAR_index.output,
-        IDX.done = 'log/benchmark/STAR_index.benchmark.txt'
+        IDX_done = 'log/benchmark/STAR_index.benchmark.txt'
     output: 
-        LOAD.done = touch('log/benchmark/STAR_load.benchmark.txt')
+        LOAD_done = touch('log/benchmark/STAR_load.benchmark.txt')
     threads: config["threads"]
     message: 'Aligning reads'
     run:
@@ -104,10 +104,10 @@ rule STAR_align:
         R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
         R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
         IDX = rules.STAR_index.output,
-        LOAD.done = 'log/benchmark/STAR_index.benchmark.txt'
+        LOAD_done = 'log/benchmark/STAR_index.benchmark.txt'
     output: 
         BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
-        ALIGN.done = touch('log/benchmark/STAR_align.benchmark.txt')
+        ALIGN_done = touch('log/benchmark/STAR_align.benchmark.txt')
     params:
         OUT = 'result/2_bam/{sample}_'
     threads: config["threads"] * 0.25
@@ -117,10 +117,10 @@ rule STAR_align:
   
 rule STAR_remove:
     input:
-        LOAD.done = 'log/benchmark/STAR_align.benchmark.txt',
+        LOAD_done = 'log/benchmark/STAR_align.benchmark.txt',
         IDX = 'ref/release' + config["release"] + '/STARindex/'
     output: 
-        REMOVE.done = touch('log/benchmark/STAR_remove.benchmark.txt')
+        REMOVE_done = touch('log/benchmark/STAR_remove.benchmark.txt')
     message: 'Removing genome from RAM'
     shell:
         """
@@ -134,7 +134,7 @@ rule STAR_remove:
 rule align_filter:
     input: 
         BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
-        REMOVE.done = 'log/benchmark/STAR_remove.benchmark.txt'
+        REMOVE_done = 'log/benchmark/STAR_remove.benchmark.txt'
     output: 'result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam'
     threads: config["threads"] * 0.1
     message: "Filtering alignments"

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -10,13 +10,14 @@ QC_trim_html = expand("result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html", samp
 QC_trim_zip = expand("result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.zip", sample=SAMPLES, suf=SUFFIX)
 BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES)
 BAM2 = expand("result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam", sample=SAMPLES)
+RM_LOG = expand("log/STAR_remove/{sample}.log", sample=SAMPLES)
 FLAGSTAT = expand("result/qc/3_flagstat/{sample}_flagstat.tsv", sample=SAMPLES)
 PICARD = expand("result/qc/4_picard/{sample}_picard.tsv", sample=SAMPLES)
 COUNT = expand("result/4_count/{sample}_feature_counts.tsv", sample=SAMPLES)
 
 rule all:
     input:
-        TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT,
+        TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + RM_LOG + FLAGSTAT + PICARD + COUNT,
         'result/5_combined/combined_feature_counts.tsv',
         'result/5_combined/combined_flagstat.tsv',
         'result/5_combined/combined_picard.tsv'

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -14,10 +14,6 @@ FLAGSTAT = expand("result/qc/3_flagstat/{sample}_flagstat.tsv", sample=SAMPLES)
 PICARD = expand("result/qc/4_picard/{sample}_picard.tsv", sample=SAMPLES)
 COUNT = expand("result/4_count/{sample}_feature_counts.tsv", sample=SAMPLES)
 
-## LOGS / BENCHMARKS
-ALIGN_done = expand("log/benchmark/STAR_align.{sample}.benchmark.txt", sample=SAMPLES)
-REMOVE_done = expand("log/benchmark/STAR_remove.{sample}.benchmark.txt", sample=SAMPLES)
-
 rule all:
     input:
         TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT + ALIGN_done + REMOVE_done,
@@ -25,7 +21,9 @@ rule all:
         'result/5_combined/combined_flagstat.tsv',
         'result/5_combined/combined_picard.tsv',
         'log/benchmark/STAR_index.benchmark.txt',
-        'log/benchmark/STAR_load.benchmark.txt'
+        'log/benchmark/STAR_load.benchmark.txt',
+        'log/benchmark/STAR_align.benchmark.txt',
+        
         
 ##----------------------------------------##
 ## 1. Adapter removal & quality filtering ##
@@ -113,10 +111,10 @@ rule STAR_align:
     input:
         R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
         R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-        LOAD_done = 'log/benchmark/STAR_index.benchmark.txt'
+        LOAD_done = 'log/benchmark/STAR_load.benchmark.txt'
     output: 
         BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
-        ALIGN_done = touch('log/benchmark/STAR_align.{sample}.benchmark.txt')
+        ALIGN_done = touch('log/benchmark/STAR_align.benchmark.txt')
     params:
         OUT = 'result/2_bam/{sample}_',
         release = config["release"]
@@ -127,9 +125,10 @@ rule STAR_align:
   
 rule STAR_remove:
     input:
-        LOAD_done = 'log/benchmark/STAR_align.{sample}.benchmark.txt'
+        LOAD_done = 'log/benchmark/STAR_load.benchmark.txt',
+        ALIGN_done = 'log/benchmark/STAR_align.benchmark.txt'
     output: 
-        REMOVE_done = touch('log/benchmark/STAR_remove.{sample}.benchmark.txt')
+        REMOVE_done = touch('log/benchmark/STAR_remove.benchmark.txt')
     params:
         release = config["release"]
     message: 'Removing genome from RAM'
@@ -146,7 +145,7 @@ rule STAR_remove:
 rule align_filter:
     input: 
         BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
-        REMOVE_done = 'log/benchmark/STAR_remove.{sample}.benchmark.txt'
+        REMOVE_done = 'log/benchmark/STAR_remove.benchmark.txt'
     output: 'result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam'
     threads: config["threads"] * 0.1
     message: "Filtering alignments"

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -77,8 +77,6 @@ if (not os.path.exists(STAR_index_SA)):
     rule STAR_index:
         input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
         output: 
-            STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
-            gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf',
             IDX_done = touch('log/benchmark/STAR_index.benchmark.txt')
         params:
             release = config["release"],
@@ -87,44 +85,51 @@ if (not os.path.exists(STAR_index_SA)):
         message: "Generating genome index"
         run:
             shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
+else:
+    rule skip_index:
+        input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
+        output: 
+            IDX_done = touch('log/benchmark/STAR_index.benchmark.txt')
+        message: "Genome index already present. Skipping indexing rule."
 
 rule STAR_load:
     input:
-        IDX = rules.STAR_index.output,
         IDX_done = 'log/benchmark/STAR_index.benchmark.txt'
     output: 
         LOAD_done = touch('log/benchmark/STAR_load.benchmark.txt')
+    params:
+        release = config["release"]
     threads: config["threads"]
-    message: 'Aligning reads'
+    message: 'Loading genome index'
     run:
-        shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+        shell("STAR --genomeDir 'ref/release{params.release}/STARindex' --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
         
 rule STAR_align:
     input:
         R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
         R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-        IDX = rules.STAR_index.output,
         LOAD_done = 'log/benchmark/STAR_index.benchmark.txt'
     output: 
         BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
         ALIGN_done = touch('log/benchmark/STAR_align.benchmark.txt')
     params:
-        OUT = 'result/2_bam/{sample}_'
+        OUT = 'result/2_bam/{sample}_',
+        release = config["release"]
     threads: config["threads"] * 0.25
     message: 'Aligning reads'
     run:
-        shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+        shell("STAR --genomeDir 'ref/release{params.release}/STARindex' --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
   
 rule STAR_remove:
     input:
-        LOAD_done = 'log/benchmark/STAR_align.benchmark.txt',
-        IDX = 'ref/release' + config["release"] + '/STARindex/'
+        LOAD_done = 'log/benchmark/STAR_align.benchmark.txt'
     output: 
         REMOVE_done = touch('log/benchmark/STAR_remove.benchmark.txt')
     message: 'Removing genome from RAM'
     shell:
         """
         STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
+        rm {input.LOAD_done}
         """
 
 ##----------------------------------------##

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -125,7 +125,7 @@ rule STAR_align:
 rule STAR_remove:
     input:
         LOAD_done = 'log/benchmark/STAR_load.benchmark.txt',
-        BAM = output.STAR_align.BAM
+        BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
     output: 
         REMOVE_done = touch('log/benchmark/STAR_remove.benchmark.txt')
     params:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -105,7 +105,7 @@ if (not os.path.exists(STAR_index_SA)):
             BAM = rules.STAR_align.output,
             IDX = 'ref/release' + config["release"] + '/STARindex/'
         message: 'Removing genome from RAM'
-        log: expand("log/STAR_remove/{sample}.log")
+        log: expand("log/STAR_remove/{sample}.log", sample=SAMPLES)
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
@@ -131,7 +131,7 @@ else:
             BAM = rules.STAR_align2.output,
             IDX = expand('ref/release{release}/STARindex', release=config["release"])
         message: 'Removing genome from RAM'
-        log: expand("log/STAR_remove/{sample}.log")
+        log: expand("log/STAR_remove/{sample}.log", sample=SAMPLES)
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -16,7 +16,7 @@ COUNT = expand("result/4_count/{sample}_feature_counts.tsv", sample=SAMPLES)
 
 rule all:
     input:
-        TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT + ALIGN_done + REMOVE_done,
+        TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT,
         'result/5_combined/combined_feature_counts.tsv',
         'result/5_combined/combined_flagstat.tsv',
         'result/5_combined/combined_picard.tsv',

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -72,24 +72,13 @@ rule fastqc_trim:
 ##----------------------------------------##
 STAR_index_SA = 'ref/release' + config["release"] + '/STARindex/SA'
 
-if (os.path.exists(STAR_index_SA)):
-    rule STAR_align:
-        input:
-            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-            IDX = STAR_index_SA
-        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-        params:
-            OUT = 'result/2_bam/{sample}_'
-        threads: config["threads"] * 0.25
-        message: 'Aligning reads'
-        run:
-            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
-else:
-    rule STAR_index2:
+if (not os.path.exists(STAR_index_SA)):
+    STAR_index = 'ref/release' + config["release"] + '/STARindex/'
+    
+    rule STAR_index:
         input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
         output: 
+            STAR_index = ancient(directory(expand('ref/release{release}/STARindex', release=config["release"]))),
             STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
             gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
         params:
@@ -99,25 +88,27 @@ else:
         message: "Generating genome index"
         run:
             shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
+else:
+    STAR_index = rules.STAR_index.output
 
-    rule STAR_align:
-        input:
-            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-            IDX = rules.STAR_index.output
-        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-        params:
-            OUT = 'result/2_bam/{sample}_'
-        threads: config["threads"] * 0.25
-        message: 'Aligning reads'
-        run:
-            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+rule STAR_align:
+    input:
+        R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+        R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+        IDX = STAR_index
+    output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+    params:
+        OUT = 'result/2_bam/{sample}_'
+    threads: config["threads"] * 0.25
+    message: 'Aligning reads'
+    run:
+        shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+        shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
   
 rule STAR_remove:
     input:
         BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES),
-        IDX = rules.STAR_index.output
+        IDX = STAR_index
     message: 'Removing genome from RAM'
     shell:
         """

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -79,7 +79,7 @@ if (not os.path.exists(STAR_index_SA)):
         output: 
             STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
             gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf',
-            IDX.done = 'log/benchmark/STAR_index.benchmark.txt'
+            IDX.done = touch('log/benchmark/STAR_index.benchmark.txt')
         params:
             release = config["release"],
             genome = config["genome"]

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -83,7 +83,7 @@ if (not os.path.exists(STAR_index_SA)):
         params:
             release = config["release"],
             genome = config["genome"]
-        threads: config["threads"] * 0.25
+        threads: config["threads"] * 0.5
         message: "Generating genome index"
         run:
             shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
@@ -101,7 +101,7 @@ rule STAR_load:
         LOAD_done = touch('log/benchmark/STAR_load.benchmark.txt')
     params:
         release = config["release"]
-    threads: config["threads"] * 0.25
+    threads: config["threads"] * 0.5
     message: 'Loading genome index'
     run:
         shell("STAR --genomeDir 'ref/release{params.release}/STARindex' --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -111,7 +111,7 @@ rule STAR_align:
         LOAD_done = 'log/benchmark/STAR_index.benchmark.txt'
     output: 
         BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
-        ALIGN_done = touch('log/benchmark/STAR_align.benchmark.txt')
+        ALIGN_done = touch('log/benchmark/STAR_align.{sample}.benchmark.txt')
     params:
         OUT = 'result/2_bam/{sample}_',
         release = config["release"]

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -110,7 +110,8 @@ rule STAR_align:
         R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
         LOAD_done = 'log/benchmark/STAR_index.benchmark.txt'
     output: 
-        BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+        BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
+        ALIGN_done = touch('log/benchmark/STAR_align.benchmark.txt')
     params:
         OUT = 'result/2_bam/{sample}_',
         release = config["release"]
@@ -121,7 +122,6 @@ rule STAR_align:
   
 rule STAR_remove:
     input:
-        BAMs = get_files(),
         LOAD_done = 'log/benchmark/STAR_align.benchmark.txt'
     output: 
         REMOVE_done = touch('log/benchmark/STAR_remove.benchmark.txt')

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -72,47 +72,33 @@ rule fastqc_trim:
 ##----------------------------------------##
 STAR_index_SA = 'ref/release' + config["release"] + '/STARindex/SA'
 
-if (os.path.exists(STAR_index_SA)):
-    rule STAR_align:
-        input:
-            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-            IDX = STAR_index_SA
-        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-        params:
-            OUT = 'result/2_bam/{sample}_'
-        threads: config["threads"] * 0.25
-        message: 'Aligning reads'
-        run:
-            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
-else:
-    rule STAR_index2:
-        input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
-        output: 
-            STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
-            gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
-        params:
-            release = config["release"],
-            genome = config["genome"]
-        threads: config["threads"]
-        message: "Generating genome index"
-        run:
+rule STAR_index:
+    input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
+    output: 
+        STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
+        gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
+    params:
+        release = config["release"],
+        genome = config["genome"]
+    threads: config["threads"]
+    message: "Generating genome index"
+    run:
+        if (not os.path.exists(STAR_index_SA)):
             shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
 
-    rule STAR_align:
-        input:
-            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-            IDX = rules.STAR_index.output
-        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-        params:
-            OUT = 'result/2_bam/{sample}_'
-        threads: config["threads"] * 0.25
-        message: 'Aligning reads'
-        run:
-            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+rule STAR_align:
+    input:
+        R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+        R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+        IDX = rules.STAR_index.output
+    output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+    params:
+        OUT = 'result/2_bam/{sample}_'
+    threads: config["threads"] * 0.25
+    message: 'Aligning reads'
+    run:
+        shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+        shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
   
 rule STAR_remove:
     input:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -113,8 +113,7 @@ rule STAR_align:
         R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
         LOAD_done = 'log/benchmark/STAR_load.benchmark.txt'
     output: 
-        BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
-        ALIGN_done = touch('log/benchmark/STAR_align.benchmark.txt')
+        BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
     params:
         OUT = 'result/2_bam/{sample}_',
         release = config["release"]
@@ -126,7 +125,7 @@ rule STAR_align:
 rule STAR_remove:
     input:
         LOAD_done = 'log/benchmark/STAR_load.benchmark.txt',
-        ALIGN_done = 'log/benchmark/STAR_align.benchmark.txt'
+        BAM = output.STAR_align.BAM
     output: 
         REMOVE_done = touch('log/benchmark/STAR_remove.benchmark.txt')
     params:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -70,19 +70,21 @@ rule fastqc_trim:
 ##----------------------------------------##
 ## 3. STAR ALIGNMENT                      ##
 ##----------------------------------------##
+STAR_index_SA = expand('ref/release{release}/STARindex/SA', release=config["release"])
 
-rule STAR_index:
-    input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
-    output: 
-        STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
-        gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
-    params:
-        release = config["release"],
-        genome = config["genome"]
-    threads: config["threads"]
-    message: "Generating genome index"
-    run:
-        shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
+if (not os.path.exists(STAR_index_SA)):
+    rule STAR_index:
+        input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
+        output: 
+            STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
+            gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
+        params:
+            release = config["release"],
+            genome = config["genome"]
+        threads: config["threads"]
+        message: "Generating genome index"
+        run:
+            shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
 
 rule STAR_align:
     input:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -102,13 +102,14 @@ if (not os.path.exists(STAR_index_SA)):
   
     rule STAR_remove:
         input:
-            BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES),
+            BAM = rules.STAR_align.output,
             IDX = 'ref/release' + config["release"] + '/STARindex/'
         message: 'Removing genome from RAM'
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
             """
+            
 else:
     rule STAR_align2:
         input:
@@ -126,7 +127,7 @@ else:
   
     rule STAR_remove2:
         input:
-            BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES),
+            BAM = rules.STAR_align2.output,
             IDX = expand('ref/release{release}/STARindex', release=config["release"])
         message: 'Removing genome from RAM'
         shell:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -110,8 +110,7 @@ rule STAR_align:
         R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
         LOAD_done = 'log/benchmark/STAR_index.benchmark.txt'
     output: 
-        BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
-        ALIGN_done = touch('log/benchmark/STAR_align.benchmark.txt')
+        BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
     params:
         OUT = 'result/2_bam/{sample}_',
         release = config["release"]
@@ -122,6 +121,7 @@ rule STAR_align:
   
 rule STAR_remove:
     input:
+        BAMs = get_files(),
         LOAD_done = 'log/benchmark/STAR_align.benchmark.txt'
     output: 
         REMOVE_done = touch('log/benchmark/STAR_remove.benchmark.txt')

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -19,8 +19,7 @@ rule all:
         TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT,
         'result/5_combined/combined_feature_counts.tsv',
         'result/5_combined/combined_flagstat.tsv',
-        'result/5_combined/combined_picard.tsv',
-        'log/STAR_remove.log'
+        'result/5_combined/combined_picard.tsv'
         
 ##----------------------------------------##
 ## 1. Adapter removal & quality filtering ##
@@ -106,7 +105,7 @@ if (not os.path.exists(STAR_index_SA)):
             BAM = rules.STAR_align.output,
             IDX = 'ref/release' + config["release"] + '/STARindex/'
         message: 'Removing genome from RAM'
-        log: "log/STAR_remove.log"
+        log: expand("log/STAR_remove/{sample}.log")
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
@@ -132,7 +131,7 @@ else:
             BAM = rules.STAR_align2.output,
             IDX = expand('ref/release{release}/STARindex', release=config["release"])
         message: 'Removing genome from RAM'
-        log: "log/STAR_remove.log"
+        log: expand("log/STAR_remove/{sample}.log")
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -182,7 +182,7 @@ rule picard:
 rule fcount:
     input:
         bam = 'result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam',
-        gtf = rules.STAR_index.output.gtf
+        gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
     output: 'result/4_count/{sample}_feature_counts.tsv'
     threads: config["threads"] * 0.1
     message: "Counting features"

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -181,7 +181,7 @@ rule picard:
 rule fcount:
     input:
         bam = 'result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam',
-        gtf = rules.STAR_index.output.gtf
+        gtf = expand('ref/release{release}/STARindex', release=config["release"])
     output: 'result/4_count/{sample}_feature_counts.tsv'
     threads: config["threads"] * 0.1
     message: "Counting features"

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -10,17 +10,22 @@ QC_trim_html = expand("result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html", samp
 QC_trim_zip = expand("result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.zip", sample=SAMPLES, suf=SUFFIX)
 BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES)
 BAM2 = expand("result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam", sample=SAMPLES)
-RM_LOG = expand("log/STAR_remove/{sample}.log", sample=SAMPLES)
 FLAGSTAT = expand("result/qc/3_flagstat/{sample}_flagstat.tsv", sample=SAMPLES)
 PICARD = expand("result/qc/4_picard/{sample}_picard.tsv", sample=SAMPLES)
 COUNT = expand("result/4_count/{sample}_feature_counts.tsv", sample=SAMPLES)
 
+## LOGS / BENCHMARKS
+ALIGN_done = expand("log/benchmark/STAR_align.{sample}.benchmark.txt", sample=SAMPLES)
+REMOVE_done = expand("log/benchmark/STAR_remove.{sample}.benchmark.txt", sample=SAMPLES)
+
 rule all:
     input:
-        TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + RM_LOG + FLAGSTAT + PICARD + COUNT,
+        TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT + ALIGN_done + REMOVE_done,
         'result/5_combined/combined_feature_counts.tsv',
         'result/5_combined/combined_flagstat.tsv',
-        'result/5_combined/combined_picard.tsv'
+        'result/5_combined/combined_picard.tsv',
+        'log/benchmark/STAR_index.benchmark.txt',
+        'log/benchmark/STAR_load.benchmark.txt'
         
 ##----------------------------------------##
 ## 1. Adapter removal & quality filtering ##

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -19,7 +19,8 @@ rule all:
         TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT,
         'result/5_combined/combined_feature_counts.tsv',
         'result/5_combined/combined_flagstat.tsv',
-        'result/5_combined/combined_picard.tsv'
+        'result/5_combined/combined_picard.tsv',
+        'log/STAR_remove.benchmark.txt'
         
 ##----------------------------------------##
 ## 1. Adapter removal & quality filtering ##

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -78,7 +78,6 @@ if (not os.path.exists(STAR_index_SA)):
     rule STAR_index:
         input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
         output: 
-            STAR_index = ancient(directory(expand('ref/release{release}/STARindex', release=config["release"]))),
             STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
             gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
         params:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -19,7 +19,8 @@ rule all:
         TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT,
         'result/5_combined/combined_feature_counts.tsv',
         'result/5_combined/combined_flagstat.tsv',
-        'result/5_combined/combined_picard.tsv'
+        'result/5_combined/combined_picard.tsv',
+        'log/STAR_remove.log'
         
 ##----------------------------------------##
 ## 1. Adapter removal & quality filtering ##
@@ -105,7 +106,7 @@ if (not os.path.exists(STAR_index_SA)):
             BAM = rules.STAR_align.output,
             IDX = 'ref/release' + config["release"] + '/STARindex/'
         message: 'Removing genome from RAM'
-        log: "log/STAR_remove.benchmark.txt"
+        log: "log/STAR_remove.log"
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
@@ -131,7 +132,7 @@ else:
             BAM = rules.STAR_align2.output,
             IDX = expand('ref/release{release}/STARindex', release=config["release"])
         message: 'Removing genome from RAM'
-        benchmark: "log/STAR_remove.benchmark.txt"
+        log: "log/STAR_remove.log"
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
@@ -206,6 +207,6 @@ rule combine:
         pic_all = 'result/5_combined/combined_picard.tsv'
     threads: 1
     message: "Combining samples"
-    benchmark: 'log/combine.benchmark.txt'
+    benchmark: 'log/fcount/combine.benchmark.txt'
     run:
         shell("python scripts/combine_samples.py")

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -83,7 +83,7 @@ rule STAR_index:
     message: "Generating genome index"
     run:
         shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
-  
+
 rule STAR_align:
     input:
         R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
@@ -94,11 +94,9 @@ rule STAR_align:
         OUT = 'result/2_bam/{sample}_'
     threads: config["threads"] * 0.25
     message: 'Aligning reads'
-    shell:
-        """
-        #STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit
-        STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000
-        """
+    run:
+        shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+        shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
   
 rule STAR_remove:
     input:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -70,7 +70,7 @@ rule fastqc_trim:
 ##----------------------------------------##
 ## 3. STAR ALIGNMENT                      ##
 ##----------------------------------------##
-STAR_index_SA = expand('ref/release{release}/STARindex/SA', release=config["release"])
+STAR_index_SA = 'ref/release' + config["release"] + '/STARindex/SA'
 
 if (not os.path.exists(STAR_index_SA)):
     rule STAR_index:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -182,7 +182,7 @@ rule picard:
 rule fcount:
     input:
         bam = 'result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam',
-        gtf = expand('ref/release{release}/STARindex', release=config["release"])
+        gtf = rules.STAR_index.output.gtf
     output: 'result/4_count/{sample}_feature_counts.tsv'
     threads: config["threads"] * 0.1
     message: "Counting features"

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -72,8 +72,22 @@ rule fastqc_trim:
 ##----------------------------------------##
 STAR_index_SA = 'ref/release' + config["release"] + '/STARindex/SA'
 
-if (not os.path.exists(STAR_index_SA)):
-    rule STAR_index:
+if (os.path.exists(STAR_index_SA)):
+    rule STAR_align:
+        input:
+            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+            IDX = STAR_index_SA
+        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+        params:
+            OUT = 'result/2_bam/{sample}_'
+        threads: config["threads"] * 0.25
+        message: 'Aligning reads'
+        run:
+            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+else:
+    rule STAR_index2:
         input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
         output: 
             STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
@@ -85,27 +99,25 @@ if (not os.path.exists(STAR_index_SA)):
         message: "Generating genome index"
         run:
             shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
-else:
-  rules.STAR_index.output = STAR_index_SA
-  
-rule STAR_align:
-    input:
-        R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-        R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-        IDX = STAR_index_SA
-    output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-    params:
-        OUT = 'result/2_bam/{sample}_'
-    threads: config["threads"] * 0.25
-    message: 'Aligning reads'
-    run:
-        shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-        shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+
+    rule STAR_align:
+        input:
+            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+            IDX = rules.STAR_index.output
+        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+        params:
+            OUT = 'result/2_bam/{sample}_'
+        threads: config["threads"] * 0.25
+        message: 'Aligning reads'
+        run:
+            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
   
 rule STAR_remove:
     input:
         BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES),
-        IDX = STAR_index_SA
+        IDX = rules.STAR_index.output
     message: 'Removing genome from RAM'
     shell:
         """

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -181,13 +181,15 @@ rule picard:
 rule fcount:
     input:
         bam = 'result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam',
-        gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf',
         IDX_done = 'log/benchmark/STAR_index.benchmark.txt'
     output: 'result/4_count/{sample}_feature_counts.tsv'
+    params:
+        release = config["release"],
+        genome = config["genome"]
     threads: config["threads"] * 0.1
     message: "Counting features"
     run:
-        shell("featureCounts -T {threads} -g gene_id -t exon -p -a {input.gtf} -o {output} {input.bam}")
+        shell("featureCounts -T {threads} -g gene_id -t exon -p -a 'ref/release{params.release}/STARref/{params.genome}.{params.release}.gtf' -o {output} {input.bam}")
 
 ##----------------------------------------##
 ## 7. COMBINE SAMPLES

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -78,77 +78,68 @@ if (not os.path.exists(STAR_index_SA)):
         input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
         output: 
             STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
-            gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
+            gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf',
+            IDX.done = 'log/benchmark/STAR_index.benchmark.txt'
         params:
             release = config["release"],
             genome = config["genome"]
-        threads: config["threads"]
+        threads: config["threads"] * 0.25
         message: "Generating genome index"
         run:
             shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
-   
-    rule STAR_align:
-        input:
-            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-            IDX = rules.STAR_index.output
-        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-        params:
-            OUT = 'result/2_bam/{sample}_'
-        threads: config["threads"] * 0.25
-        message: 'Aligning reads'
-        run:
-            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+
+rule STAR_load:
+    input:
+        IDX = rules.STAR_index.output,
+        IDX.done = 'log/benchmark/STAR_index.benchmark.txt'
+    output: 
+        LOAD.done = touch('log/benchmark/STAR_load.benchmark.txt')
+    threads: config["threads"]
+    message: 'Aligning reads'
+    run:
+        shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+        
+rule STAR_align:
+    input:
+        R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+        R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+        IDX = rules.STAR_index.output,
+        LOAD.done = 'log/benchmark/STAR_index.benchmark.txt'
+    output: 
+        BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
+        ALIGN.done = touch('log/benchmark/STAR_align.benchmark.txt')
+    params:
+        OUT = 'result/2_bam/{sample}_'
+    threads: config["threads"] * 0.25
+    message: 'Aligning reads'
+    run:
+        shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
   
-    rule STAR_remove:
-        input:
-            BAM = rules.STAR_align.output,
-            IDX = 'ref/release' + config["release"] + '/STARindex/'
-        message: 'Removing genome from RAM'
-        log: expand("log/STAR_remove/{sample}.log", sample=SAMPLES)
-        shell:
-            """
-            STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
-            """
-            
-else:
-    rule STAR_align2:
-        input:
-            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-            IDX = expand('ref/release{release}/STARindex', release=config["release"])
-        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-        params:
-            OUT = 'result/2_bam/{sample}_'
-        threads: config["threads"] * 0.25
-        message: 'Aligning reads'
-        run:
-            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
-  
-    rule STAR_remove2:
-        input:
-            BAM = rules.STAR_align2.output,
-            IDX = expand('ref/release{release}/STARindex', release=config["release"])
-        message: 'Removing genome from RAM'
-        log: expand("log/STAR_remove/{sample}.log", sample=SAMPLES)
-        shell:
-            """
-            STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
-            """
+rule STAR_remove:
+    input:
+        LOAD.done = 'log/benchmark/STAR_align.benchmark.txt',
+        IDX = 'ref/release' + config["release"] + '/STARindex/'
+    output: 
+        REMOVE.done = touch('log/benchmark/STAR_remove.benchmark.txt')
+    message: 'Removing genome from RAM'
+    shell:
+        """
+        STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
+        """
 
 ##----------------------------------------##
 ## 4. ALIGNMENT FILTERING                 ##
 ##----------------------------------------##
 
 rule align_filter:
-    input: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+    input: 
+        BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
+        REMOVE.done = 'log/benchmark/STAR_remove.benchmark.txt'
     output: 'result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam'
     threads: config["threads"] * 0.1
     message: "Filtering alignments"
     run:
-        shell("samtools view {input} -h -f 3 -F 1284 -q 30 -@ {threads} > {output}")
+        shell("samtools view {input.BAM} -h -f 3 -F 1284 -q 30 -@ {threads} > {output}")
 
 ##----------------------------------------##
 ## 5. ALIGNMENT QC                        ##
@@ -207,6 +198,6 @@ rule combine:
         pic_all = 'result/5_combined/combined_picard.tsv'
     threads: 1
     message: "Combining samples"
-    benchmark: 'log/fcount/combine.benchmark.txt'
+    benchmark: 'log/benchmark/combine.benchmark.txt'
     run:
         shell("python scripts/combine_samples.py")

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -72,8 +72,22 @@ rule fastqc_trim:
 ##----------------------------------------##
 STAR_index_SA = 'ref/release' + config["release"] + '/STARindex/SA'
 
-if (not os.path.exists(STAR_index_SA)):
-    rule STAR_index:
+if (os.path.exists(STAR_index_SA)):
+    rule STAR_align:
+        input:
+            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+            IDX = STAR_index_SA
+        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+        params:
+            OUT = 'result/2_bam/{sample}_'
+        threads: config["threads"] * 0.25
+        message: 'Aligning reads'
+        run:
+            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+else:
+    rule STAR_index2:
         input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
         output: 
             STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
@@ -86,19 +100,19 @@ if (not os.path.exists(STAR_index_SA)):
         run:
             shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
 
-rule STAR_align:
-    input:
-        R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-        R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-        IDX = rules.STAR_index.output
-    output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-    params:
-        OUT = 'result/2_bam/{sample}_'
-    threads: config["threads"] * 0.25
-    message: 'Aligning reads'
-    run:
-        shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-        shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+    rule STAR_align:
+        input:
+            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+            IDX = rules.STAR_index.output
+        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+        params:
+            OUT = 'result/2_bam/{sample}_'
+        threads: config["threads"] * 0.25
+        message: 'Aligning reads'
+        run:
+            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
   
 rule STAR_remove:
     input:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -122,9 +122,9 @@ rule STAR_align:
   
 rule STAR_remove:
     input:
-        LOAD_done = 'log/benchmark/STAR_align.benchmark.txt'
+        LOAD_done = 'log/benchmark/STAR_align.{sample}.benchmark.txt'
     output: 
-        REMOVE_done = touch('log/benchmark/STAR_remove.benchmark.txt')
+        REMOVE_done = touch('log/benchmark/STAR_remove.{sample}.benchmark.txt')
     message: 'Removing genome from RAM'
     shell:
         """
@@ -139,7 +139,7 @@ rule STAR_remove:
 rule align_filter:
     input: 
         BAM = 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam',
-        REMOVE_done = 'log/benchmark/STAR_remove.benchmark.txt'
+        REMOVE_done = 'log/benchmark/STAR_remove.{sample}.benchmark.txt'
     output: 'result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam'
     threads: config["threads"] * 0.1
     message: "Filtering alignments"

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -19,7 +19,8 @@ rule all:
         TRIM1 + TRIM2 + QC_trim_html + QC_trim_zip + BAM + BAM2 + FLAGSTAT + PICARD + COUNT,
         'result/5_combined/combined_feature_counts.tsv',
         'result/5_combined/combined_flagstat.tsv',
-        'result/5_combined/combined_picard.tsv'
+        'result/5_combined/combined_picard.tsv',
+        'log/STAR_remove.log'
         
 ##----------------------------------------##
 ## 1. Adapter removal & quality filtering ##
@@ -105,6 +106,7 @@ if (not os.path.exists(STAR_index_SA)):
             BAM = rules.STAR_align.output,
             IDX = 'ref/release' + config["release"] + '/STARindex/'
         message: 'Removing genome from RAM'
+        log: "log/STAR_remove.log"
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
@@ -130,6 +132,7 @@ else:
             BAM = rules.STAR_align2.output,
             IDX = expand('ref/release{release}/STARindex', release=config["release"])
         message: 'Removing genome from RAM'
+        log: "log/STAR_remove.log"
         shell:
             """
             STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -21,8 +21,7 @@ rule all:
         'result/5_combined/combined_flagstat.tsv',
         'result/5_combined/combined_picard.tsv',
         'log/benchmark/STAR_index.benchmark.txt',
-        'log/benchmark/STAR_load.benchmark.txt',
-        'log/benchmark/STAR_align.benchmark.txt',
+        'log/benchmark/STAR_load.benchmark.txt'
         
         
 ##----------------------------------------##

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -73,8 +73,6 @@ rule fastqc_trim:
 STAR_index_SA = 'ref/release' + config["release"] + '/STARindex/SA'
 
 if (not os.path.exists(STAR_index_SA)):
-    STAR_index = 'ref/release' + config["release"] + '/STARindex/'
-    
     rule STAR_index:
         input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
         output: 
@@ -87,33 +85,55 @@ if (not os.path.exists(STAR_index_SA)):
         message: "Generating genome index"
         run:
             shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
-else:
-    STAR_index = rules.STAR_index.output
-
-rule STAR_align:
-    input:
-        R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-        R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-        IDX = STAR_index
-    output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-    params:
-        OUT = 'result/2_bam/{sample}_'
-    threads: config["threads"] * 0.25
-    message: 'Aligning reads'
-    run:
-        shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-        shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+   
+    rule STAR_align:
+        input:
+            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+            IDX = rules.STAR_index.output
+        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+        params:
+            OUT = 'result/2_bam/{sample}_'
+        threads: config["threads"] * 0.25
+        message: 'Aligning reads'
+        run:
+            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
   
-rule STAR_remove:
-    input:
-        BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES),
-        IDX = STAR_index
-    message: 'Removing genome from RAM'
-    shell:
-        """
-        STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
-        """
-        
+    rule STAR_remove:
+        input:
+            BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES),
+            IDX = 'ref/release' + config["release"] + '/STARindex/'
+        message: 'Removing genome from RAM'
+        shell:
+            """
+            STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
+            """
+else:
+    rule STAR_align2:
+        input:
+            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+            IDX = directory(expand('ref/release{release}/STARindex', release=config["release"]))
+        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+        params:
+            OUT = 'result/2_bam/{sample}_'
+        threads: config["threads"] * 0.25
+        message: 'Aligning reads'
+        run:
+            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+  
+    rule STAR_remove2:
+        input:
+            BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES),
+            IDX = directory(expand('ref/release{release}/STARindex', release=config["release"]))
+        message: 'Removing genome from RAM'
+        shell:
+            """
+            STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
+            """
+
 ##----------------------------------------##
 ## 4. ALIGNMENT FILTERING                 ##
 ##----------------------------------------##

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -72,22 +72,8 @@ rule fastqc_trim:
 ##----------------------------------------##
 STAR_index_SA = 'ref/release' + config["release"] + '/STARindex/SA'
 
-if (os.path.exists(STAR_index_SA)):
-    rule STAR_align:
-        input:
-            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-            IDX = STAR_index_SA
-        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-        params:
-            OUT = 'result/2_bam/{sample}_'
-        threads: config["threads"] * 0.25
-        message: 'Aligning reads'
-        run:
-            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
-else:
-    rule STAR_index2:
+if (not os.path.exists(STAR_index_SA)):
+    rule STAR_index:
         input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
         output: 
             STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
@@ -99,25 +85,27 @@ else:
         message: "Generating genome index"
         run:
             shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
-
-    rule STAR_align:
-        input:
-            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-            IDX = rules.STAR_index.output
-        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-        params:
-            OUT = 'result/2_bam/{sample}_'
-        threads: config["threads"] * 0.25
-        message: 'Aligning reads'
-        run:
-            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+else:
+  rules.STAR_index.output = STAR_index_SA
+  
+rule STAR_align:
+    input:
+        R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+        R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+        IDX = STAR_index_SA
+    output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+    params:
+        OUT = 'result/2_bam/{sample}_'
+    threads: config["threads"] * 0.25
+    message: 'Aligning reads'
+    run:
+        shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+        shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
   
 rule STAR_remove:
     input:
         BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES),
-        IDX = rules.STAR_index.output
+        IDX = STAR_index_SA
     message: 'Removing genome from RAM'
     shell:
         """

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -181,7 +181,8 @@ rule picard:
 rule fcount:
     input:
         bam = 'result/3_bam_filter/{sample}_Aligned.sortedByCoord.filter.bam',
-        gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
+        gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf',
+        IDX_done = 'log/benchmark/STAR_index.benchmark.txt'
     output: 'result/4_count/{sample}_feature_counts.tsv'
     threads: config["threads"] * 0.1
     message: "Counting features"

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -72,33 +72,47 @@ rule fastqc_trim:
 ##----------------------------------------##
 STAR_index_SA = 'ref/release' + config["release"] + '/STARindex/SA'
 
-rule STAR_index:
-    input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
-    output: 
-        STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
-        gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
-    params:
-        release = config["release"],
-        genome = config["genome"]
-    threads: config["threads"]
-    message: "Generating genome index"
-    run:
-        if (not os.path.exists(STAR_index_SA)):
+if (os.path.exists(STAR_index_SA)):
+    rule STAR_align:
+        input:
+            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+            IDX = STAR_index_SA
+        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+        params:
+            OUT = 'result/2_bam/{sample}_'
+        threads: config["threads"] * 0.25
+        message: 'Aligning reads'
+        run:
+            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+else:
+    rule STAR_index2:
+        input: expand('result/qc/2_fastqc_trim/{sample}_{suf}_fastqc.html', sample=SAMPLES, suf=SUFFIX)
+        output: 
+            STAR_index = directory(expand('ref/release{release}/STARindex', release=config["release"])),
+            gtf = 'ref/release' + config["release"] + '/STARref/' + config["genome"] + '.' + config["release"] + '.gtf'
+        params:
+            release = config["release"],
+            genome = config["genome"]
+        threads: config["threads"]
+        message: "Generating genome index"
+        run:
             shell("scripts/STAR_index.sh {params.release} {params.genome} {threads}")
 
-rule STAR_align:
-    input:
-        R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
-        R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-        IDX = rules.STAR_index.output
-    output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
-    params:
-        OUT = 'result/2_bam/{sample}_'
-    threads: config["threads"] * 0.25
-    message: 'Aligning reads'
-    run:
-        shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
-        shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
+    rule STAR_align:
+        input:
+            R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
+            R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
+            IDX = rules.STAR_index.output
+        output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
+        params:
+            OUT = 'result/2_bam/{sample}_'
+        threads: config["threads"] * 0.25
+        message: 'Aligning reads'
+        run:
+            shell("STAR --genomeDir {input.IDX} --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndExit")
+            shell("STAR --genomeDir {input.IDX} --readFilesIn {input.R1} {input.R2} --readFilesCommand zcat --outFileNamePrefix {params.OUT} --outSAMtype BAM SortedByCoordinate --runThreadN {threads} --runRNGseed 8756 --genomeLoad LoadAndKeep --limitBAMsortRAM 20000000000")
   
 rule STAR_remove:
     input:

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -130,10 +130,12 @@ rule STAR_remove:
         LOAD_done = 'log/benchmark/STAR_align.{sample}.benchmark.txt'
     output: 
         REMOVE_done = touch('log/benchmark/STAR_remove.{sample}.benchmark.txt')
+    params:
+        release = config["release"]
     message: 'Removing genome from RAM'
     shell:
         """
-        STAR --genomeDir {input.IDX} --runRNGseed 8756 --genomeLoad Remove
+        STAR --genomeDir 'ref/release{params.release}/STARindex' --runRNGseed 8756 --genomeLoad Remove
         rm {input.LOAD_done}
         """
 

--- a/Snakefile_step2
+++ b/Snakefile_step2
@@ -114,7 +114,7 @@ else:
         input:
             R1 = "result/1_trim/{sample}_R1_trim.fastq.gz",
             R2 = "result/1_trim/{sample}_R2_trim.fastq.gz",
-            IDX = directory(expand('ref/release{release}/STARindex', release=config["release"]))
+            IDX = expand('ref/release{release}/STARindex', release=config["release"])
         output: 'result/2_bam/{sample}_Aligned.sortedByCoord.out.bam'
         params:
             OUT = 'result/2_bam/{sample}_'
@@ -127,7 +127,7 @@ else:
     rule STAR_remove2:
         input:
             BAM = expand("result/2_bam/{sample}_Aligned.sortedByCoord.out.bam", sample=SAMPLES),
-            IDX = directory(expand('ref/release{release}/STARindex', release=config["release"]))
+            IDX = expand('ref/release{release}/STARindex', release=config["release"])
         message: 'Removing genome from RAM'
         shell:
             """


### PR DESCRIPTION
**Describe the purpose of these changes**
Resolves RAM issues with STAR alignment. Forcing indexing only when index is not already present. Loads index once per run, instead of once per file. Remove index from RAM prior to proceeding with downstream steps

**Tests**

- [x] Runs with example data
- [x] Vignette updated